### PR TITLE
Add disable option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # IDEs #
 .idea
-.iml
+*.iml
 .settings
 .externalToolBuilders
 .classpath

--- a/mods/bukkit/src/main/java/com/drevelopment/amplechatbot/bukkit/BukkitPlugin.java
+++ b/mods/bukkit/src/main/java/com/drevelopment/amplechatbot/bukkit/BukkitPlugin.java
@@ -26,11 +26,15 @@ import com.drevelopment.amplechatbot.core.util.LocaleHandler;
 
 public class BukkitPlugin extends JavaPlugin {
 
+    public static boolean enabled = true;
+
 	private Logger logger;
 
 	@Override
 	public void onEnable() {
 		logger = this.getLogger();
+
+        getCommand("ampletoggle").setExecutor(new ToggleCommandExecutor());
 
 		Ample.setEventHandler(new SimpleEventHandler());
 		Ample.setCommandHandler(new SimpleCommandHandler());

--- a/mods/bukkit/src/main/java/com/drevelopment/amplechatbot/bukkit/ToggleCommandExecutor.java
+++ b/mods/bukkit/src/main/java/com/drevelopment/amplechatbot/bukkit/ToggleCommandExecutor.java
@@ -1,0 +1,22 @@
+package com.drevelopment.amplechatbot.bukkit;
+
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+
+public class ToggleCommandExecutor implements CommandExecutor {
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!sender.hasPermission("ample.toggle")) {
+            sender.sendMessage("§cNo permission.");
+            return true;
+        }
+        BukkitPlugin.enabled = !BukkitPlugin.enabled;
+        if (BukkitPlugin.enabled) {
+            sender.sendMessage("§6The AmpleChatBot is now enabled.");
+        } else {
+            sender.sendMessage("§6The AmpleChatBot is now disabled.");
+        }
+        return true;
+    }
+}

--- a/mods/bukkit/src/main/java/com/drevelopment/amplechatbot/bukkit/listeners/BukkitListener.java
+++ b/mods/bukkit/src/main/java/com/drevelopment/amplechatbot/bukkit/listeners/BukkitListener.java
@@ -67,7 +67,7 @@ public class BukkitListener implements Listener {
 
 	@EventHandler
 	public void onChat(AsyncPlayerChatEvent event) {
-		if (!event.isCancelled()) {
+        if (BukkitPlugin.enabled && !event.isCancelled()) {
 			Ample.getEventHandler().post(new PlayerChatEvent(Ample.getModTransformer().getPlayer(event.getPlayer().getUniqueId().toString()), event.getMessage()));
 		}
 	}

--- a/mods/bukkit/src/main/resources/plugin.yml
+++ b/mods/bukkit/src/main/resources/plugin.yml
@@ -23,6 +23,9 @@ commands:
  ample:
   description: Displays help for this plugin.
   usage: /<command> <subcommand>
+ ampletoggle:
+  description: Toggle active state of the bot
+  usage: /<command>
 
 permissions:
  ample.*:
@@ -35,6 +38,7 @@ permissions:
    ample.delete: true
    ample.say: true
    ample.allowabuse: true
+   ample.toggle: true
  ample.invoke:
   description: Allows people to invoke responses.
   default: true
@@ -52,4 +56,7 @@ permissions:
   default: op
  ample.allowabuse:
   description: Allows to bypass abuse routines.
+  default: op
+ ample.toggle:
+  description: Allows to toggle active state of the bot.
   default: op


### PR DESCRIPTION
The command `/ampletoggle` now toggles whether the bot will be notified about new chat messages; this is only saved in memory.

The command is only available on the bukkit platform.
